### PR TITLE
Hyperlink

### DIFF
--- a/lib/generate.js
+++ b/lib/generate.js
@@ -6,7 +6,7 @@ var xml2js = require('xml2js'),
     loadDetails = null,
     parsedDetailsCache = {}; // temp - static hash cache of details {versionname :details}
 
-// public get the page object json from the xml file 
+// public get the page object json from the xml file
 var getDetails = function(detailsfile, modulename, version, cb){
     var detailsCache = __getDetailsCache(version);
     if (detailsCache !=null) {
@@ -19,7 +19,7 @@ var getDetails = function(detailsfile, modulename, version, cb){
         loadDetails(detailsfile, version, function(result){
             process.nextTick(function(){
                 var pageObject = _getRootPageObject(modulename, result);
-                cb(pageObject);
+               cb(pageObject);
             });            
         });
     }
@@ -71,7 +71,10 @@ var __getDetailsCache = function (version) {
 }
 var __setDetailsCache = function(version, details){
     parsedDetailsCache[version] = details;
-}
+
+    // setup global to be used by objectExists()
+    details.javascript.object.forEach(function(obj){ _pages[obj.$.location] = true; });
+};
 
 // public
 var loadDetails = function (detailsfile, version, cb) {
@@ -113,7 +116,7 @@ generate = function(detailsfile /* file to details.xml*/, modulename /*module ob
                 }
                 
                 if (pageObject.summary){ // allow null property
-                    retObjectItem.summary = pageObject.summary;
+                    retObjectItem.summary = [autoHyperlink(pageObject.summary[0])];    // call autoHyperLink() for testing
                 }
                 if (pageObject.description){ // allow null property
                     retObjectItem.description = pageObject.description;
@@ -165,7 +168,7 @@ generate = function(detailsfile /* file to details.xml*/, modulename /*module ob
                 }
                 // end kwargs
 
-                // todo: //	hyperlink to relevant reference doc page, if one exists                 
+                // todo: //	hyperlink to relevant reference doc page, if one exists
                 //retstr += "<p>See the <a href='#" +modulename +"' target='_blank'>"+ modulename + " reference documentation</a> for more information.</p>";
 
                 // generate properties
@@ -260,24 +263,119 @@ var getMethodOrEventObjects = function(methods){
     return lclMethods; // allow empty
 }
 
+// Root URL used to construct hyperlinks
+// temporary: this should come for a config file... or something
+var baseUrl = "/";
+
+var _pages = {};
+var objectExists = function(page){
+    // Function to look up if specified page exists
+    return _pages[page];
+};
+
+function hyperlink(text, label){
+    // summary:
+    //      Convert text to a hyperlink if it looks like a link to a module.
+    //      Return text as-is if it's something like "Boolean".
+    //      Assumes that details{} global has been setup with hash of pages of documentation.
+    // text: String
+    //      String to convert to hyperlink
+    // label: String
+    //      If specified, use this as the hyperlink label, rather than text
+
+    var url = null;
+    if(objectExists(text)){
+        url = text;
+    }else if(/\./.test(text) && objectExists(text.replace("/\..*/", ""))){
+        // Text like dojo/on.emit where there is no separate page for emit(), so turn into a URL like dojo/on#emit
+        url = text.replace(".", "#");
+    }
+
+    if(url){
+        return '<a class="jsdoc-link" href="' + baseUrl + url + '">'
+            + ( label || text)
+            + '</a>';
+    }else{
+        // Word like "Boolean"
+        return text;
+    }
+}
+
 var trimSummary = function(summary, firstSentence){
-	// summary:
-	//		Strip tags and returns the first sentence of specified string
+    // summary:
+    //      Strip tags and returns the first sentence of specified string
 
-	// Looking for a period followed by a space or newline, and then a capital letter.
-	// But since $summary matches the formatting of the original HTML, maybe we should just
-	// look for a newline... not sure.
+    // Looking for a period followed by a space or newline, and then a capital letter.
+    // But since $summary matches the formatting of the original HTML, maybe we should just
+    // look for a newline... not sure.
 
-	var summaryLcl = strip_tags(summary);
+    var summaryLcl = strip_tags(summary);
 
-	if(firstSentence === true){
-		//$summary = preg_replace("/(\\.|!|\\?)[\s]+[A-Z].*/s", "\\1", summaryLcl);
-		//summaryLcl = summaryLcl.replace(/(\\.|!|\\?)[\s]+[A-Z].*/s, "");
-		//summaryLcl.replace(/^(.*?)[.?!]\s/, "");
-		summaryLcl = summaryLcl.match(/^.*$/m)[0]; // this is really naff and the wrong regex, it'll do for now but needs to be fixed - also why repeat part of the summary twice?
-	}
+    if(firstSentence){
+        //$summary = preg_replace("/(\\.|!|\\?)[\s]+[A-Z].*/s", "\\1", summaryLcl);
+        //summaryLcl = summaryLcl.replace(/(\\.|!|\\?)[\s]+[A-Z].*/s, "");
+        //summaryLcl.replace(/^(.*?)[.?!]\s/, "");
+        summaryLcl = summaryLcl.match(/^.*$/m)[0]; // this is really naff and the wrong regex, it'll do for now but needs to be fixed - also why repeat part of the summary twice?
+    }
 
 	return summaryLcl.trim();
+}
+
+
+function autoHyperlink(text){
+    // summary:
+    //      Search summary/description for patterns like dojo/hccss, dijit/Tree.TreeNode, or acme/myfunc(a, b, c),
+    //       and convert to hyperlinks
+
+    // Split text into code examples and segments of free text, and then insert hyperlinks in free text segments
+    var inExample = false;
+    return text.split(/(<pre><code>|<\/code><\/pre>)/ ).map(function(part){
+        if(part == "<pre><code>"){
+            inExample = true;
+            return "<pre><code>";
+        }else if(part == "</code></pre>"){
+            return "</pre></code>";
+            inExample = false;
+        }else if(inExample){
+            // Don't try to stick hyperlinks into code examples
+            return part;
+        }else{
+            // Find likely module references, ex:
+            //      dijit/Tree
+            //      dijit/Tree.TreeNode
+            //      dojo/dom-style.set(a, b)
+            // .. or any of the above surrounded by <code>...</code>
+            //
+            // Regex designed to not include the period ending a sentence, ex:
+            //      For more info, see dijit/Tree.
+            return part.replace(
+                /(<code>|)([a-zA-Z0-9]+\/[-a-zA-Z0-9_]+([\.\/][-a-zA-Z0-9_]+)*)(\([^(]*\)|)(<\/code>|)/,
+                function(wholeString, codeStart, path, linkSuffix, parameters, codeEnd){
+                // parameters:
+                //      wholeString: the whole string
+                //      codeStart: "<code>" or ""
+                //      path: the link, ex: dijit/form/Button.set
+                //      linkSuffix: .set (ignore this)
+                //      parameters:    parameter string like "(a, b)", or ""
+                //      codeEnd: "</code>" or ""
+
+                // the label for the hyperlink should be the original text, but without the <code> wrapper
+                var label = path + parameters;
+
+                // try to convert matched string to a hyperlink to another module
+                debugger;
+                var link = hyperlink(path, label);
+
+                if(link != path){
+                    // replaced <code>foo/bar</code> with <a ...>foo/bar<a>
+                    return link;
+                }else{
+                    // hyperlink() didn't do a conversion, so this is probably something else, so don't change it, leave <code>
+                    return wholeString;
+                }
+            });
+        }
+    });
 }
 
 var strip_tags = function (str, allow) {


### PR DESCRIPTION
Prototype code for hyperlink support.

Right now it needs to create a global _pages variable to work, for the objectExists() method to tell if there's a page or not for a given value like "dijit/Dialog".

It's also generating HTML links from javascript, based on a baseUrl variable that should be configurable, rather than hardcoded to "/".

And also, it only processes the page level summaries.   That's just to prove that it's working.  hyperlink() or autoHyperlink() should eventually be called on summaries, descriptions, return-descriptions, parameter types, property types, return types, "from module", and lists of superclasses.   (Maybe some other stuff too that I forgot.)

Didn't mean to include the lint changes in this pull request, but added them by accident.
