### PR TITLE
fix trimSummary to work as before, taking first sentence

### DIFF
--- a/lib/generate.js
+++ b/lib/generate.js
@@ -264,18 +264,12 @@ var trimSummary = function(summary, firstSentence){
 	// summary:
 	//		Strip tags and returns the first sentence of specified string
 
-	// Looking for a period followed by a space or newline, and then a capital letter.
-	// But since $summary matches the formatting of the original HTML, maybe we should just
-	// look for a newline... not sure.
-
 	var summaryLcl = strip_tags(summary);
 
-	if(firstSentence === true){
-		//$summary = preg_replace("/(\\.|!|\\?)[\s]+[A-Z].*/s", "\\1", summaryLcl);
-		//summaryLcl = summaryLcl.replace(/(\\.|!|\\?)[\s]+[A-Z].*/s, "");
-		//summaryLcl.replace(/^(.*?)[.?!]\s/, "");
-		summaryLcl = summaryLcl.match(/^.*$/m)[0]; // this is really naff and the wrong regex, it'll do for now but needs to be fixed - also why repeat part of the summary twice?
-	}
+    if(firstSentence){
+        // Look for a period followed by a space or newline, and then a capital letter.
+        summaryLcl = summaryLcl.replace(/(\.|!|\?)[\s]+[A-Z].*/, "$1")
+    }
 
 	return summaryLcl.trim();
 }


### PR DESCRIPTION
The (current) API viewer shows a short explanation and a long explanation for each method, event, module, etc.   Often the code though just has one block of documentation, ex:

```
    _onDropDownMouseUp: function(/*Event?*/ e){
        // summary:
        //      Callback on mouseup/touchend after mousedown/touchstart on the arrow icon.
        //      Note that this function is called regardless of what node the event occurred on (but only after
        //      a mousedown/touchstart on the arrow).
        //
        //      If the drop down is a simple menu and the cursor is over the menu, we execute it, otherwise, we focus our
        //      drop down widget.  If the event is missing, then we are not
        //      a mouseup event.
        //
        //      This is useful for the common mouse movement pattern
        //      with native browser `<select>` nodes:
        //
        //      1. mouse down on the select node (probably on the arrow)
        //      2. move mouse to a menu item while holding down the mouse button
        //      3. mouse up.  this selects the menu item as though the user had clicked it.
```

In that case we want to use the first sentence for the short explanation, and the full text for the long explanation.   An alternate approach would be to use the first paragraph.   Using the first row of text though doesn't make sense because it may stop in the middle of a sentence.
